### PR TITLE
Fix security groups

### DIFF
--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -10,11 +10,11 @@ name = "emr-test"
 
 ebs_root_volume_size = 10
 
-visible_to_all_users = false
+visible_to_all_users = true
 
 release_label = "emr-5.25.0"
 
-applications = ["Hadoop", "Hive", "Presto"]
+applications = ["Hive", "Presto"]
 
 core_instance_group_instance_type = "m4.large"
 
@@ -41,21 +41,3 @@ create_task_instance_group = false
 ssh_public_key_path = "/secrets"
 
 generate_ssh_key = true
-
-# https://docs.aws.amazon.com/emr/latest/ReleaseGuide/emr-configure-apps.html
-configurations_json = <<EOF
-  [
-    {
-      "Classification": "hadoop-env",
-      "Configurations": [
-        {
-          "Classification": "export",
-          "Properties": {
-            "JAVA_HOME": "/usr/lib/jvm/java-1.8.0"
-          }
-        }
-      ],
-      "Properties": {}
-    }
-  ]
-EOF

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -46,6 +46,7 @@ variable "applications" {
 variable "configurations_json" {
   type        = string
   description = "A JSON string for supplying list of configurations for the EMR cluster"
+  default     = null
 }
 
 variable "core_instance_group_instance_type" {

--- a/main.tf
+++ b/main.tf
@@ -58,27 +58,6 @@ module "label_task" {
   attributes = compact(concat(module.label.attributes, list("task")))
 }
 
-module "label_master_managed" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.14.1"
-  enabled    = var.enabled
-  context    = module.label.context
-  attributes = compact(concat(module.label.attributes, list("master", "managed")))
-}
-
-module "label_slave_managed" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.14.1"
-  enabled    = var.enabled
-  context    = module.label.context
-  attributes = compact(concat(module.label.attributes, list("slave", "managed")))
-}
-
-module "label_service_managed" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.14.1"
-  enabled    = var.enabled
-  context    = module.label.context
-  attributes = compact(concat(module.label.attributes, list("service", "managed")))
-}
-
 /*
 NOTE on EMR-Managed security groups: These security groups will have any missing inbound or outbound access rules added and maintained by AWS,
 to ensure proper communication between instances in a cluster. The EMR service will maintain these rules for groups provided

--- a/main.tf
+++ b/main.tf
@@ -58,6 +58,27 @@ module "label_task" {
   attributes = compact(concat(module.label.attributes, list("task")))
 }
 
+module "label_master_managed" {
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.14.1"
+  enabled    = var.enabled
+  context    = module.label.context
+  attributes = compact(concat(module.label.attributes, list("master", "managed")))
+}
+
+module "label_slave_managed" {
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.14.1"
+  enabled    = var.enabled
+  context    = module.label.context
+  attributes = compact(concat(module.label.attributes, list("slave", "managed")))
+}
+
+module "label_service_managed" {
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.14.1"
+  enabled    = var.enabled
+  context    = module.label.context
+  attributes = compact(concat(module.label.attributes, list("service", "managed")))
+}
+
 /*
 NOTE on EMR-Managed security groups: These security groups will have any missing inbound or outbound access rules added and maintained by AWS,
 to ensure proper communication between instances in a cluster. The EMR service will maintain these rules for groups provided
@@ -72,6 +93,84 @@ emr_managed_master_security_group and emr_managed_slave_security_group.
 # https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-sg-specify.html
 # https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-man-sec-groups.html
 # https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-clusters-in-a-vpc.html
+
+resource "aws_security_group" "managed_master" {
+  count                  = var.enabled ? 1 : 0
+  revoke_rules_on_delete = true
+  vpc_id                 = var.vpc_id
+  name                   = module.label_master_managed.id
+  description            = "EmrManagedMasterSecurityGroup"
+  tags                   = module.label_master_managed.tags
+
+  # EMR will update "ingress" and "egress" so we ignore the changes here
+  lifecycle {
+    ignore_changes = ["ingress", "egress"]
+  }
+}
+
+resource "aws_security_group_rule" "managed_master_egress" {
+  count             = var.enabled ? 1 : 0
+  description       = "Allow all egress traffic"
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  ipv6_cidr_blocks  = ["::/0"]
+  security_group_id = join("", aws_security_group.managed_master.*.id)
+}
+
+resource "aws_security_group" "managed_slave" {
+  count                  = var.enabled ? 1 : 0
+  revoke_rules_on_delete = true
+  vpc_id                 = var.vpc_id
+  name                   = module.label_slave_managed.id
+  description            = "EmrManagedSlaveSecurityGroup"
+  tags                   = module.label_slave_managed.tags
+
+  # EMR will update "ingress" and "egress" so we ignore the changes here
+  lifecycle {
+    ignore_changes = ["ingress", "egress"]
+  }
+}
+
+resource "aws_security_group_rule" "managed_slave_egress" {
+  count             = var.enabled ? 1 : 0
+  description       = "Allow all egress traffic"
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  ipv6_cidr_blocks  = ["::/0"]
+  security_group_id = join("", aws_security_group.managed_slave.*.id)
+}
+
+resource "aws_security_group" "managed_service_access" {
+  count                  = var.enabled && var.subnet_type == "private" ? 1 : 0
+  revoke_rules_on_delete = true
+  vpc_id                 = var.vpc_id
+  name                   = module.label_service_managed.id
+  description            = "EmrManagedServiceAccessSecurityGroup"
+  tags                   = module.label_service_managed.tags
+
+  # EMR will update "ingress" and "egress" so we ignore the changes here
+  lifecycle {
+    ignore_changes = ["ingress", "egress"]
+  }
+}
+
+resource "aws_security_group_rule" "managed_service_access_egress" {
+  count             = var.enabled && var.subnet_type == "private" ? 1 : 0
+  description       = "Allow all egress traffic"
+  type              = "egress"
+  from_port         = 0
+  to_port           = 0
+  protocol          = "-1"
+  cidr_blocks       = ["0.0.0.0/0"]
+  ipv6_cidr_blocks  = ["::/0"]
+  security_group_id = join("", aws_security_group.managed_service_access.*.id)
+}
 
 # Specify additional master and slave security groups
 resource "aws_security_group" "master" {
@@ -259,6 +358,9 @@ resource "aws_emr_cluster" "default" {
   ec2_attributes {
     key_name                          = var.key_name
     subnet_id                         = var.subnet_id
+    emr_managed_master_security_group = join("", aws_security_group.managed_master.*.id)
+    emr_managed_slave_security_group  = join("", aws_security_group.managed_slave.*.id)
+    service_access_security_group     = var.subnet_type == "private" ? join("", aws_security_group.managed_service_access.*.id) : null
     instance_profile                  = join("", aws_iam_instance_profile.ec2.*.arn)
     additional_master_security_groups = join("", aws_security_group.master.*.id)
     additional_slave_security_groups  = join("", aws_security_group.slave.*.id)


### PR DESCRIPTION
## what
* Update egress for EMR managed security groups
* Set `visible_to_all_users` to `true`

## why
* EMR will create and maintain rules for all managed security groups for master, slave and service access (when in private subnet). EMR will add all the required ingress and egress rules to the groups

* When you specify managed security groups for a cluster, you must use the same type of security group, default or custom, for all managed security groups. For example, you can't specify a custom security group for the master instance, and then not specify a custom security group for core and task instances.

* If `visible_to_all_users` is set to false, the cluster, after it's created, is not visible even to terraform 

## references
* https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-sg-specify.html
* https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-man-sec-groups.html
* https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-clusters-in-a-vpc.html
