### PR TITLE
Added application-autoscaling.amazonaws.com as Trusted entity for e…

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,11 +358,11 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 |---|---|---|
 
   [osterman_homepage]: https://github.com/osterman
-  [osterman_avatar]: https://github.com/osterman.png?size=150
+  [osterman_avatar]: https://img.cloudposse.com/150x150/https://github.com/osterman.png
   [aknysh_homepage]: https://github.com/aknysh
-  [aknysh_avatar]: https://github.com/aknysh.png?size=150
+  [aknysh_avatar]: https://img.cloudposse.com/150x150/https://github.com/aknysh.png
   [goruha_homepage]: https://github.com/goruha
-  [goruha_avatar]: https://github.com/goruha.png?size=150
+  [goruha_avatar]: https://img.cloudposse.com/150x150/https://github.com/goruha.png
 
 
 

--- a/main.tf
+++ b/main.tf
@@ -339,7 +339,7 @@ https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-iam-roles.html
 resource "aws_iam_role" "ec2_autoscaling" {
   count              = var.enabled ? 1 : 0
   name               = module.label_ec2_autoscaling.id
-  assume_role_policy = join("", data.aws_iam_policy_document.assume_role_ec2.*.json)
+  assume_role_policy = join("", data.aws_iam_policy_document.assume_role_emr.*.json)
 }
 
 # https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-iam-roles.html

--- a/main.tf
+++ b/main.tf
@@ -270,7 +270,7 @@ data "aws_iam_policy_document" "assume_role_emr" {
 
     principals {
       type        = "Service"
-      identifiers = ["elasticmapreduce.amazonaws.com","application-autoscaling.amazonaws.com"]
+      identifiers = ["elasticmapreduce.amazonaws.com", "application-autoscaling.amazonaws.com"]
     }
 
     actions = ["sts:AssumeRole"]

--- a/main.tf
+++ b/main.tf
@@ -270,7 +270,7 @@ data "aws_iam_policy_document" "assume_role_emr" {
 
     principals {
       type        = "Service"
-      identifiers = ["elasticmapreduce.amazonaws.com"]
+      identifiers = ["elasticmapreduce.amazonaws.com","application-autoscaling.amazonaws.com"]
     }
 
     actions = ["sts:AssumeRole"]


### PR DESCRIPTION
Earlier autoscaling policy is failing to attach with the error

Failed to provision the AutoScaling policy: Unable to assume IAM role: arn:aws:iam::216727*****:role/emr-stage-dataorc-emr-ec2-autoscaling

this is due to absence of application-autoscaling.amazonaws.com as Trusted entity