### PR TITLE
Add `var.create_vpc_endpoint_s3` to control S3 endpoint creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ Available targets:
 | core_instance_group_instance_count | Target number of instances for the Core instance group. Must be at least 1 | number | `1` | no |
 | core_instance_group_instance_type | EC2 instance type for all instances in the Core instance group | string | - | yes |
 | create_task_instance_group | Whether to create an instance group for Task nodes. For more info: https://www.terraform.io/docs/providers/aws/r/emr_instance_group.html, https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-master-core-task-nodes.html | bool | `false` | no |
+| create_vpc_endpoint_s3 | Set to false to prevent the module from creating VPC S3 Endpoint | bool | `true` | no |
 | custom_ami_id | A custom Amazon Linux AMI for the cluster (instead of an EMR-owned AMI). Available in Amazon EMR version 5.7.0 and later | string | `null` | no |
 | delimiter | Delimiter between `namespace`, `stage`, `name` and `attributes` | string | `-` | no |
 | ebs_root_volume_size | Size in GiB of the EBS root device volume of the Linux AMI that is used for each EC2 instance. Available in Amazon EMR version 4.x and later | number | `10` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -16,6 +16,7 @@
 | core_instance_group_instance_count | Target number of instances for the Core instance group. Must be at least 1 | number | `1` | no |
 | core_instance_group_instance_type | EC2 instance type for all instances in the Core instance group | string | - | yes |
 | create_task_instance_group | Whether to create an instance group for Task nodes. For more info: https://www.terraform.io/docs/providers/aws/r/emr_instance_group.html, https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-master-core-task-nodes.html | bool | `false` | no |
+| create_vpc_endpoint_s3 | Set to false to prevent the module from creating VPC S3 Endpoint | bool | `true` | no |
 | custom_ami_id | A custom Amazon Linux AMI for the cluster (instead of an EMR-owned AMI). Available in Amazon EMR version 5.7.0 and later | string | `null` | no |
 | delimiter | Delimiter between `namespace`, `stage`, `name` and `attributes` | string | `-` | no |
 | ebs_root_volume_size | Size in GiB of the EBS root device volume of the Linux AMI that is used for each EC2 instance. Available in Amazon EMR version 4.x and later | number | `10` | no |

--- a/main.tf
+++ b/main.tf
@@ -480,7 +480,7 @@ module "dns_master" {
 # https://www.terraform.io/docs/providers/aws/r/vpc_endpoint.html
 # https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-clusters-in-a-vpc.html
 resource "aws_vpc_endpoint" "vpc_endpoint_s3" {
-  count           = var.enabled && var.subnet_type == "private" ? 1 : 0
+  count           = var.enabled && var.subnet_type == "private" && var.create_vpc_endpoint_s3 ? 1 : 0
   vpc_id          = var.vpc_id
   service_name    = format("com.amazonaws.%s.s3", var.region)
   auto_accept     = true

--- a/variables.tf
+++ b/variables.tf
@@ -335,3 +335,9 @@ variable "bootstrap_action" {
   description = "List of bootstrap actions that will be run before Hadoop is started on the cluster nodes"
   default     = []
 }
+
+variable "create_vpc_endpoint_s3" {
+  type        = bool
+  description = "Endpoint ID for VPC S3 Endpoint"
+  default     = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -338,6 +338,6 @@ variable "bootstrap_action" {
 
 variable "create_vpc_endpoint_s3" {
   type        = bool
-  description = "Endpoint ID for VPC S3 Endpoint"
+  description = "Set to false to prevent the module from creating VPC S3 Endpoint"
   default     = true
 }


### PR DESCRIPTION
## what
* Add the variable `create_vpc_endpoint_s3` to control VPC S3 Endpoint creation

## why
* Users may already have their own S3 Endpoint in the selected VPC. If they do, this module fails because there can only be one.

