### PR TITLE
fix: unquote references in ignore_changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Available targets:
 
 ```
 <!-- markdownlint-restore -->
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -260,6 +261,7 @@ Available targets:
 | master\_security\_group\_id | Master security group ID |
 | slave\_security\_group\_id | Slave security group ID |
 
+<!-- markdownlint-restore -->
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -93,3 +94,4 @@
 | master\_security\_group\_id | Master security group ID |
 | slave\_security\_group\_id | Slave security group ID |
 
+<!-- markdownlint-restore -->

--- a/main.tf
+++ b/main.tf
@@ -104,7 +104,7 @@ resource "aws_security_group" "managed_master" {
 
   # EMR will update "ingress" and "egress" so we ignore the changes here
   lifecycle {
-    ignore_changes = ["ingress", "egress"]
+    ignore_changes = [ingress, egress]
   }
 }
 
@@ -130,7 +130,7 @@ resource "aws_security_group" "managed_slave" {
 
   # EMR will update "ingress" and "egress" so we ignore the changes here
   lifecycle {
-    ignore_changes = ["ingress", "egress"]
+    ignore_changes = [ingress, egress]
   }
 }
 
@@ -156,7 +156,7 @@ resource "aws_security_group" "managed_service_access" {
 
   # EMR will update "ingress" and "egress" so we ignore the changes here
   lifecycle {
-    ignore_changes = ["ingress", "egress"]
+    ignore_changes = [ingress, egress]
   }
 }
 
@@ -464,7 +464,7 @@ resource "aws_emr_cluster" "default" {
 
   # configurations_json changes are ignored because of terraform bug. Configuration changes are applied via local.bootstrap_action.
   lifecycle {
-    ignore_changes = ["kerberos_attributes", "step", "configurations_json"]
+    ignore_changes = [kerberos_attributes, step, configurations_json]
   }
 }
 


### PR DESCRIPTION
## what
* remove terraform 0.11 warnings, i.e.: 
```
on .terraform/modules/emr_cluster/main.tf line 467, in resource "aws_emr_cluster" "default":
 467:     ignore_changes = ["kerberos_attributes", "step", "configurations_json"]

In this context, references are expected literally rather than in quotes.
Terraform 0.11 and earlier required quotes, but quoted references are now
deprecated and will be removed in a future version of Terraform. Remove the
quotes surrounding this reference to silence this warning.
```

## why
* avoid these warnings in logs

