### PR TITLE
fix: add ingress rule from managed master to service

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Available targets:
 
 ```
 <!-- markdownlint-restore -->
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -260,6 +261,7 @@ Available targets:
 | master\_security\_group\_id | Master security group ID |
 | slave\_security\_group\_id | Slave security group ID |
 
+<!-- markdownlint-restore -->
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -93,3 +94,4 @@
 | master\_security\_group\_id | Master security group ID |
 | slave\_security\_group\_id | Slave security group ID |
 
+<!-- markdownlint-restore -->

--- a/main.tf
+++ b/main.tf
@@ -160,6 +160,20 @@ resource "aws_security_group" "managed_service_access" {
   }
 }
 
+resource "aws_security_group_rule" "managed_master_service_access_ingress" {
+  for_each = {
+    for index, security_group in aws_security_group.managed_service_access :
+    index => security_group.id
+  }
+  description              = "Allow ingress traffic from EmrManagedMasterSecurityGroup"
+  type                     = "ingress"
+  from_port                = 9443
+  to_port                  = 9443
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.managed_master[each.key].id
+  security_group_id        = each.value
+}
+
 resource "aws_security_group_rule" "managed_service_access_egress" {
   count             = var.enabled && var.subnet_type == "private" ? 1 : 0
   description       = "Allow all egress traffic"

--- a/main.tf
+++ b/main.tf
@@ -161,17 +161,14 @@ resource "aws_security_group" "managed_service_access" {
 }
 
 resource "aws_security_group_rule" "managed_master_service_access_ingress" {
-  for_each = {
-    for index, security_group in aws_security_group.managed_service_access :
-    index => security_group.id
-  }
+  count                    = var.enabled && var.subnet_type == "private" ? 1 : 0
   description              = "Allow ingress traffic from EmrManagedMasterSecurityGroup"
   type                     = "ingress"
   from_port                = 9443
   to_port                  = 9443
   protocol                 = "tcp"
-  source_security_group_id = aws_security_group.managed_master[each.key].id
-  security_group_id        = each.value
+  source_security_group_id = aws_security_group.managed_master[count.index].id
+  security_group_id        = aws_security_group.managed_service_access[count.index].id
 }
 
 resource "aws_security_group_rule" "managed_service_access_egress" {

--- a/main.tf
+++ b/main.tf
@@ -168,7 +168,7 @@ resource "aws_security_group_rule" "managed_master_service_access_ingress" {
   to_port                  = 9443
   protocol                 = "tcp"
   source_security_group_id = join("", aws_security_group.managed_master.*.id)
-  security_group_id        = aws_security_group.managed_service_access[count.index].id
+  security_group_id        = join("", aws_security_group.managed_service_access.*.id)
 }
 
 resource "aws_security_group_rule" "managed_service_access_egress" {

--- a/main.tf
+++ b/main.tf
@@ -167,7 +167,7 @@ resource "aws_security_group_rule" "managed_master_service_access_ingress" {
   from_port                = 9443
   to_port                  = 9443
   protocol                 = "tcp"
-  source_security_group_id = aws_security_group.managed_master[count.index].id
+  source_security_group_id = join("", aws_security_group.managed_master.*.id)
   security_group_id        = aws_security_group.managed_service_access[count.index].id
 }
 


### PR DESCRIPTION
## what
* add ingress rule on TCP 9443 from managed master to service security group

## why
* emr-5.30.* requires this rule to be present

## references
* https://github.com/terraform-providers/terraform-provider-aws/issues/14338

