### PR TITLE
Expose ec2 role

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Available targets:
 
 ```
 <!-- markdownlint-restore -->
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -255,12 +256,13 @@ Available targets:
 |------|-------------|
 | cluster\_id | EMR cluster ID |
 | cluster\_name | EMR cluster name |
+| ec2\_role | Role name of EMR EC2 instances so users can attach more policies |
 | master\_host | Name of the cluster CNAME record for the master nodes in the parent DNS zone |
 | master\_public\_dns | Master public DNS |
 | master\_security\_group\_id | Master security group ID |
 | slave\_security\_group\_id | Slave security group ID |
-| ec2_role | Role name of EMR EC2 instances so users can attach more policies |
 
+<!-- markdownlint-restore -->
 
 
 

--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ Available targets:
 | master\_public\_dns | Master public DNS |
 | master\_security\_group\_id | Master security group ID |
 | slave\_security\_group\_id | Slave security group ID |
+| ec2_role | Role name of EMR EC2 instances so users can attach more policies |
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -88,8 +89,10 @@
 |------|-------------|
 | cluster\_id | EMR cluster ID |
 | cluster\_name | EMR cluster name |
+| ec2\_role | Role name of EMR EC2 instances so users can attach more policies |
 | master\_host | Name of the cluster CNAME record for the master nodes in the parent DNS zone |
 | master\_public\_dns | Master public DNS |
 | master\_security\_group\_id | Master security group ID |
 | slave\_security\_group\_id | Slave security group ID |
 
+<!-- markdownlint-restore -->

--- a/outputs.tf
+++ b/outputs.tf
@@ -27,3 +27,8 @@ output "master_host" {
   value       = module.dns_master.hostname
   description = "Name of the cluster CNAME record for the master nodes in the parent DNS zone"
 }
+
+output "ec2_role" {
+  value       = join("", aws_iam_role.ec2.*.name)
+  description = "Role name of EMR EC2 instances so users can attach more policies"
+}


### PR DESCRIPTION
## what
* Added ec2_role output that expose the role name of EMR EC2 instances

## why
* The output allow users of the module to append additional policies to EC2 role

