### PR TITLE
Include Steps option in aws_emr_cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Available targets:
 | slave\_allowed\_security\_groups | List of security groups to be allowed to connect to the slave instances | `list(string)` | `[]` | no |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | step\_concurrency\_level | The number of steps that can be executed concurrently. You can specify a maximum of 256 steps. Only valid for EMR clusters with release\_label 5.28.0 or greater. | `number` | `null` | no |
-| steps | List of steps to run when creating the cluster. | <pre>list(object({<br>    name = string<br>    action_on_failure = string<br>    hadoop_jar_step = object({<br>      args       = list(string)<br>      jar        = string<br>      main_class = string<br>      properties = map(string)<br>    })<br>  }))</pre> | `[]` | no |
+| steps | List of steps to run when creating the cluster. | <pre>list(object({<br>    name              = string<br>    action_on_failure = string<br>    hadoop_jar_step = object({<br>      args       = list(string)<br>      jar        = string<br>      main_class = string<br>      properties = map(string)<br>    })<br>  }))</pre> | `[]` | no |
 | subnet\_id | VPC subnet ID where you want the job flow to launch. Cannot specify the `cc1.4xlarge` instance type for nodes of a job flow launched in a Amazon VPC | `string` | n/a | yes |
 | subnet\_type | Type of VPC subnet ID where you want the job flow to launch. Supported values are `private` or `public` | `string` | `"private"` | no |
 | tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |

--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ Available targets:
 | slave\_allowed\_security\_groups | List of security groups to be allowed to connect to the slave instances | `list(string)` | `[]` | no |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | step\_concurrency\_level | The number of steps that can be executed concurrently. You can specify a maximum of 256 steps. Only valid for EMR clusters with release\_label 5.28.0 or greater. | `number` | `null` | no |
+| steps | List of steps to run when creating the cluster. | <pre>list(object({<br>    name = string<br>    action_on_failure = string<br>    hadoop_jar_step = object({<br>      args       = list(string)<br>      jar        = string<br>      main_class = string<br>      properties = map(string)<br>    })<br>  }))</pre> | `[]` | no |
 | subnet\_id | VPC subnet ID where you want the job flow to launch. Cannot specify the `cc1.4xlarge` instance type for nodes of a job flow launched in a Amazon VPC | `string` | n/a | yes |
 | subnet\_type | Type of VPC subnet ID where you want the job flow to launch. Supported values are `private` or `public` | `string` | `"private"` | no |
 | tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -74,6 +74,7 @@
 | slave\_allowed\_security\_groups | List of security groups to be allowed to connect to the slave instances | `list(string)` | `[]` | no |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | step\_concurrency\_level | The number of steps that can be executed concurrently. You can specify a maximum of 256 steps. Only valid for EMR clusters with release\_label 5.28.0 or greater. | `number` | `null` | no |
+| steps | List of steps to run when creating the cluster. | <pre>list(object({<br>    name = string<br>    action_on_failure = string<br>    hadoop_jar_step = object({<br>      args       = list(string)<br>      jar        = string<br>      main_class = string<br>      properties = map(string)<br>    })<br>  }))</pre> | `[]` | no |
 | subnet\_id | VPC subnet ID where you want the job flow to launch. Cannot specify the `cc1.4xlarge` instance type for nodes of a job flow launched in a Amazon VPC | `string` | n/a | yes |
 | subnet\_type | Type of VPC subnet ID where you want the job flow to launch. Supported values are `private` or `public` | `string` | `"private"` | no |
 | tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -74,7 +74,7 @@
 | slave\_allowed\_security\_groups | List of security groups to be allowed to connect to the slave instances | `list(string)` | `[]` | no |
 | stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
 | step\_concurrency\_level | The number of steps that can be executed concurrently. You can specify a maximum of 256 steps. Only valid for EMR clusters with release\_label 5.28.0 or greater. | `number` | `null` | no |
-| steps | List of steps to run when creating the cluster. | <pre>list(object({<br>    name = string<br>    action_on_failure = string<br>    hadoop_jar_step = object({<br>      args       = list(string)<br>      jar        = string<br>      main_class = string<br>      properties = map(string)<br>    })<br>  }))</pre> | `[]` | no |
+| steps | List of steps to run when creating the cluster. | <pre>list(object({<br>    name              = string<br>    action_on_failure = string<br>    hadoop_jar_step = object({<br>      args       = list(string)<br>      jar        = string<br>      main_class = string<br>      properties = map(string)<br>    })<br>  }))</pre> | `[]` | no |
 | subnet\_id | VPC subnet ID where you want the job flow to launch. Cannot specify the `cc1.4xlarge` instance type for nodes of a job flow launched in a Amazon VPC | `string` | n/a | yes |
 | subnet\_type | Type of VPC subnet ID where you want the job flow to launch. Supported values are `private` or `public` | `string` | `"private"` | no |
 | tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -445,6 +445,20 @@ resource "aws_emr_cluster" "default" {
     }
   }
 
+  dynamic "step" {
+    for_each = var.steps
+    content {
+      name                                = step.value.name
+      action_on_failure                   = step.value.action_on_failure
+      hadoop_jar_step {
+        jar                               = step.value.hadoop_jar_step["jar"]
+        main_class                        = lookup(step.value.hadoop_jar_step, "main_class", null)
+        properties                        = lookup(step.value.hadoop_jar_step, "properties", null)
+        args                              = lookup(step.value.hadoop_jar_step, "args", null)
+      }
+    }
+  }
+
   configurations_json = var.configurations_json
 
   log_uri = var.log_uri

--- a/main.tf
+++ b/main.tf
@@ -448,13 +448,13 @@ resource "aws_emr_cluster" "default" {
   dynamic "step" {
     for_each = var.steps
     content {
-      name                                = step.value.name
-      action_on_failure                   = step.value.action_on_failure
+      name              = step.value.name
+      action_on_failure = step.value.action_on_failure
       hadoop_jar_step {
-        jar                               = step.value.hadoop_jar_step["jar"]
-        main_class                        = lookup(step.value.hadoop_jar_step, "main_class", null)
-        properties                        = lookup(step.value.hadoop_jar_step, "properties", null)
-        args                              = lookup(step.value.hadoop_jar_step, "args", null)
+        jar        = step.value.hadoop_jar_step["jar"]
+        main_class = lookup(step.value.hadoop_jar_step, "main_class", null)
+        properties = lookup(step.value.hadoop_jar_step, "properties", null)
+        args       = lookup(step.value.hadoop_jar_step, "args", null)
       }
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -342,3 +342,18 @@ variable "kerberos_realm" {
   description = "The name of the Kerberos realm to which all nodes in a cluster belong. For example, EC2.INTERNAL"
   default     = "EC2.INTERNAL"
 }
+
+variable "steps" {
+  type = list(object({
+    name = string
+    action_on_failure = string
+    hadoop_jar_step = object({
+      args       = list(string)
+      jar        = string
+      main_class = string
+      properties = map(string)
+    })
+  }))
+  description = "List of steps to run when creating the cluster."
+  default     = []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -345,7 +345,7 @@ variable "kerberos_realm" {
 
 variable "steps" {
   type = list(object({
-    name = string
+    name              = string
     action_on_failure = string
     hadoop_jar_step = object({
       args       = list(string)


### PR DESCRIPTION
## what
You should be able to add steps to this module.

## why
It was initially requested to allow debugging, but it should allow a user to add any steps that they can in the main AWS EMR Terraform 

## references
closes #7

