### PR TITLE
Add support for auto termination policy, resolves #53

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -494,6 +494,13 @@ resource "aws_emr_cluster" "default" {
   lifecycle {
     ignore_changes = [kerberos_attributes, step, configurations_json]
   }
+
+  dynamic auto_termination_policy {
+    for_each = var.auto_termination_idle_timeout ? [var.auto_termination_idle_timeout] : []
+    content {
+      idle_timeout = var.auto_termination_idle_timeout
+    }
+  }
 }
 
 # https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-master-core-task-nodes.html

--- a/variables.tf
+++ b/variables.tf
@@ -472,3 +472,9 @@ variable "ec2_autoscaling_role_permissions_boundary" {
   description = "The Permissions Boundary ARN to apply to the EC2 Autoscaling Role."
   default     = ""
 }
+
+variable "auto_termination_idle_timeout" {
+  type        = string
+  description = "Auto termination policy idle timeout in seconds (60 - 604800 supported)"
+  default     = null
+}


### PR DESCRIPTION
## what
Adds support for defining auto termination policy as described in https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/emr_cluster#auto_termination_policy

## why
Auto termination lets the user schedule termination of the cluster if it is idle for a predefined time.
See more in #53 

## references

Closes #53 
